### PR TITLE
Fixing Typo and correcting Commands order

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Type following commands
 git add .
 git commit -m "message about commit"
 ```
-### 8. Configure a Remote for the Fork
+### 7. Configure a Remote for the Fork
 
 Next, you’ll have to specify a new remote upstream repository for us to sync with the fork. This will be the original repository that you forked from. You’ll have to do this with the `git remote add` command.
 
@@ -86,7 +86,7 @@ git remote add upstream https://github.com/ALLINONE4298/Hacktober2020.git
 
 In this example, `upstream` is the shortname we have supplied for the remote repository since in terms of Git, “upstream” refers to the repository that you cloned from. If you want to add a remote pointer to the repository of a collaborator, you may want to provide that collaborator’s username or a shortened nickname for the shortname.
 
-### 7. Pull changes 
+### 8. Pull changes 
 
 To get latest code
 Type following command 

--- a/README.md
+++ b/README.md
@@ -76,16 +76,6 @@ Type following commands
 git add .
 git commit -m "message about commit"
 ```
-
-### 7. Pull changes 
-
-To get latest code
-Type following command 
-
-```
-git pull upstream master
-```
-
 ### 8. Configure a Remote for the Fork
 
 Next, you’ll have to specify a new remote upstream repository for us to sync with the fork. This will be the original repository that you forked from. You’ll have to do this with the `git remote add` command.
@@ -95,6 +85,15 @@ git remote add upstream https://github.com/ALLINONE4298/Hacktober2020.git
 ```
 
 In this example, `upstream` is the shortname we have supplied for the remote repository since in terms of Git, “upstream” refers to the repository that you cloned from. If you want to add a remote pointer to the repository of a collaborator, you may want to provide that collaborator’s username or a shortened nickname for the shortname.
+
+### 7. Pull changes 
+
+To get latest code
+Type following command 
+
+```
+git pull upstream main
+```
 
 ### 9. Push changes to Github
 


### PR DESCRIPTION
1. Changing "master" to "main" branch in git command 
2. Correcting order for declaring "upstream" and using "upstream"